### PR TITLE
Add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,23 @@ To setup the repository locally follow the steps mentioned below:
 3. Get the ERPNext app and install it
    ```
    # Get the ERPNext app
-   bench get-app https://github.com/frappe/erpnext
+   bench get-app https://github.com/naturae-syria/erpnext
 
    # Install the app
    bench --site erpnext.localhost install-app erpnext
    ```
 
 4. Open the URL `http://erpnext.localhost:8000/app` in your browser, you should see the app running
+
+### Debian 12 Installation Script
+
+For a quick start on Debian&nbsp;12 you can run the helper script:
+
+```bash
+./scripts/install_debian12.sh
+```
+
+The script installs bench, creates a site and starts the server using the steps mentioned above.
 
 ## Learning and community
 

--- a/scripts/install_debian12.sh
+++ b/scripts/install_debian12.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Simple installer for ERPNext on Debian 12
+# This script installs bench, creates a site and starts the server
+set -euo pipefail
+
+# Update package lists and install basic dependencies
+sudo apt update
+sudo apt install -y git python3-dev python3-setuptools python3-pip python3-venv \
+    build-essential redis-server mariadb-server mariadb-client default-libmysqlclient-dev \
+    wkhtmltopdf curl nodejs npm
+
+# Install bench
+sudo pip3 install frappe-bench
+
+# Initialize a bench instance
+bench init --frappe-path https://github.com/frappe/frappe --skip-assets frappe-bench
+cd frappe-bench
+
+# Create a new site with default credentials
+bench new-site --admin-password admin --mariadb-root-password root erpnext.localhost
+
+# Get ERPNext app from GitHub
+bench get-app https://github.com/naturae-syria/erpnext
+
+# Install the app on the new site
+bench --site erpnext.localhost install-app erpnext
+
+# Build assets and start the server
+bench build
+bench start


### PR DESCRIPTION
## Summary
- add helper install script for Debian 12
- document script in README
- switch install instructions to use naturae-syria/erpnext repo

## Testing
- `ruff check .` *(fails: numerous errors)*
- `pytest -q` *(fails during collection with ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_684e1cd3a4a083308319267756567d2c