### PR TITLE
Add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ To setup the repository locally follow the steps mentioned below:
 
 4. Open the URL `http://erpnext.localhost:8000/app` in your browser, you should see the app running
 
+### Debian 12 Installation Script
+
+For a quick start on Debian&nbsp;12 you can run the helper script:
+
+```bash
+./scripts/install_debian12.sh
+```
+
+The script installs bench, creates a site using [bench](https://github.com/frappe/bench),
+fetches the ERPNext app from
+[naturae-syria/erpnext](https://github.com/naturae-syria/erpnext), and starts the server.
+It uses pip's `--break-system-packages` option so that Debian's externally managed
+environment does not block the installation.
+
 ## Learning and community
 
 1. [Frappe School](https://school.frappe.io) - Learn Frappe Framework and ERPNext from the various courses by the maintainers or from the community.

--- a/scripts/install_debian12.sh
+++ b/scripts/install_debian12.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Simple installer for ERPNext on Debian 12
+# This script installs bench, creates a site and starts the server
+set -euo pipefail
+
+# Update package lists and install basic dependencies
+sudo apt update
+sudo apt install -y git python3-dev python3-setuptools python3-pip python3-venv \
+    build-essential redis-server mariadb-server mariadb-client default-libmysqlclient-dev \
+    wkhtmltopdf curl nodejs npm
+
+# Install bench with --break-system-packages to avoid PEP 668 errors
+sudo pip3 install --break-system-packages frappe-bench
+
+# Initialize a bench instance
+bench init --frappe-path https://github.com/frappe/frappe --skip-assets frappe-bench
+cd frappe-bench
+
+# Create a new site with default credentials
+bench new-site --admin-password admin --mariadb-root-password root erpnext.localhost
+
+# Get ERPNext app from GitHub
+bench get-app https://github.com/naturae-syria/erpnext
+
+# Install the app on the new site
+bench --site erpnext.localhost install-app erpnext
+
+# Build assets and start the server
+bench build
+bench start


### PR DESCRIPTION
## Summary
- add helper install script for Debian 12
- document script in README
- script pulls app from naturae-syria repo
- use `--break-system-packages` for bench install on Debian

## Testing
- `ruff check .` *(fails: 196 errors)*
- `pytest -q` *(fails during collection with ModuleNotFoundError: 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_684e1cd3a4a083308319267756567d2c