### PR TITLE
Fix Debian 12 install script

### DIFF
--- a/scripts/install_debian12.sh
+++ b/scripts/install_debian12.sh
@@ -10,7 +10,7 @@ sudo apt install -y git python3-dev python3-setuptools python3-pip python3-venv 
     wkhtmltopdf curl nodejs npm
 
 # Install bench
-sudo pip3 install frappe-bench
+sudo pip3 install --break-system-packages frappe-bench
 
 # Initialize a bench instance
 bench init --frappe-path https://github.com/frappe/frappe --skip-assets frappe-bench


### PR DESCRIPTION
## Summary
- fix install script for Debian 12 by allowing pip to modify system packages

## Testing
- `bash -n scripts/install_debian12.sh`
- `pytest erpnext/tests/test_init.py::TestInit::test_encode_company_abbr` *(fails: ModuleNotFoundError: No module named 'frappe')*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_684e2205b5848330a16009564293edda