### PR TITLE
Fix MariaDB root access error

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ To setup the repository locally follow the steps mentioned below:
    bench start
    ```
 
+   If `bench new-site` fails with `Access denied for user 'root'@'localhost'`,
+   configure MariaDB so the `root` user can authenticate with a password:
+   ```bash
+   sudo mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'root';"
+   sudo mysql -e "FLUSH PRIVILEGES;"
+   ```
+   Replace `root` with the password you'll pass using
+   `--mariadb-root-password`.
+
 2. In a separate terminal window, run the following commands:
    ```
    # Create a new site

--- a/scripts/install_debian12.sh
+++ b/scripts/install_debian12.sh
@@ -20,6 +20,12 @@ build-essential redis-server mariadb-server mariadb-client default-libmysqlclien
 wkhtmltopdf curl nodejs npm
 }
 
+configure_mariadb() {
+    log "Configuring MariaDB root password"
+    sudo mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '${DB_ROOT_PASSWORD}'"
+    sudo mysql -e "FLUSH PRIVILEGES"
+}
+
 setup_node() {
 if ! command -v node >/dev/null; then
 curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
@@ -59,13 +65,14 @@ bench start
 }
 
 main() {
-install_dependencies
-setup_node
-install_bench
-init_bench
-create_site
-install_erpnext
-build_and_start
+    install_dependencies
+    configure_mariadb
+    setup_node
+    install_bench
+    init_bench
+    create_site
+    install_erpnext
+    build_and_start
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- clarify how to set MariaDB root password if `bench new-site` fails
- automatically set root password in Debian install script

## Testing
- `bash -n scripts/install_debian12.sh`
- `ruff check erpnext` *(fails: many existing lint errors)*
- `pytest -k "nonexistent"` *(fails: ModuleNotFoundError for `frappe`)*
- `pip install pre-commit` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684e2d67444c8330a87493430f688ede