### PR TITLE
Fix MariaDB root password setup

### DIFF
--- a/scripts/install_debian12.sh
+++ b/scripts/install_debian12.sh
@@ -22,8 +22,12 @@ wkhtmltopdf curl nodejs npm
 
 configure_mariadb() {
     log "Configuring MariaDB root password"
-    sudo mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '${DB_ROOT_PASSWORD}'"
-    sudo mysql -e "FLUSH PRIVILEGES"
+    if sudo mysql -u root -e "SELECT 1" >/dev/null 2>&1; then
+        sudo mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '${DB_ROOT_PASSWORD}'"
+    else
+        sudo mysql -u root -p"${DB_ROOT_PASSWORD}" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '${DB_ROOT_PASSWORD}'"
+    fi
+    sudo mysql -u root -p"${DB_ROOT_PASSWORD}" -e "FLUSH PRIVILEGES"
 }
 
 setup_node() {


### PR DESCRIPTION
## Summary
- handle root password when configuring MariaDB in the Debian installer

## Testing
- `bash -n scripts/install_debian12.sh`
- `pytest erpnext/tests/test_init.py -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_684e317c04f4833090188558848235c5