### PR TITLE
Fix debian installer pkg-config error

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ To setup the repository locally follow the steps mentioned below:
    Replace `root` with the password you'll pass using
    `--mariadb-root-password`.
 
+> **Note**: The bench setup requires `pkg-config`. On Debian-based systems,
+> install it using `sudo apt-get install pkg-config` before running bench
+> commands.
+
 2. In a separate terminal window, run the following commands:
    ```
    # Create a new site

--- a/scripts/install_debian12.sh
+++ b/scripts/install_debian12.sh
@@ -16,7 +16,7 @@ log "Updating package lists"
 sudo apt-get update
 log "Installing dependencies"
 sudo apt-get install -y git python3-dev python3-setuptools python3-pip python3-venv \
-build-essential redis-server mariadb-server mariadb-client default-libmysqlclient-dev \
+build-essential pkg-config redis-server mariadb-server mariadb-client default-libmysqlclient-dev \
 wkhtmltopdf curl nodejs npm
 }
 


### PR DESCRIPTION
## Summary
- install `pkg-config` in the Debian 12 helper script
- mention the pkg-config requirement in the README

## Testing
- `bash -n scripts/install_debian12.sh`
- `pytest -k ""` *(fails: 345 errors during collection)*
- `ruff check --select I --fix scripts/install_debian12.sh README.md` *(fails: error unexpected argument '--select')*

------
https://chatgpt.com/codex/tasks/task_e_68508db63cb083308728878a2995e355