### PR TITLE
Use nvm for node install

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ To setup the repository locally follow the steps mentioned below:
 > install it using `sudo apt-get install pkg-config` before running bench
 > commands.
 
+> **Note**: ERPNext requires Node.js and Yarn for building assets. If `apt` fails
+> to install `nodejs` or `npm` due to dependency issues, install Node.js using
+> [nvm](https://github.com/nvm-sh/nvm):
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+> export NVM_DIR="$HOME/.nvm"
+> [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+> nvm install 18
+> npm install -g yarn
+> ```
+
 2. In a separate terminal window, run the following commands:
    ```
    # Create a new site

--- a/scripts/install_debian12.sh
+++ b/scripts/install_debian12.sh
@@ -17,7 +17,7 @@ sudo apt-get update
 log "Installing dependencies"
 sudo apt-get install -y git python3-dev python3-setuptools python3-pip python3-venv \
 build-essential pkg-config redis-server mariadb-server mariadb-client default-libmysqlclient-dev \
-wkhtmltopdf curl nodejs npm
+wkhtmltopdf curl
 }
 
 configure_mariadb() {
@@ -31,11 +31,15 @@ configure_mariadb() {
 }
 
 setup_node() {
-if ! command -v node >/dev/null; then
-curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-sudo apt-get install -y nodejs
-fi
-sudo npm install -g yarn
+    if ! command -v node >/dev/null; then
+        # Install nvm and Node.js 18
+        curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+        export NVM_DIR="$HOME/.nvm"
+        # shellcheck disable=SC1090
+        [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+        nvm install 18
+    fi
+    npm install -g yarn
 }
 
 install_bench() {


### PR DESCRIPTION
## Summary
- update install script to use nvm instead of apt for node
- document how to install Node.js via nvm

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a41973f083309108762e56935328